### PR TITLE
Fix Robolectric ClassLoader conflict with ByteBuddy instrumentation

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -82,7 +82,7 @@ jobs:
             Add to your `build.gradle`:
             ```kotlin
             dependencies {
-                testImplementation("io.github.takahirom:code-path-tracer:${{ github.ref_name }}")
+                testImplementation("io.github.takahirom.codepathtracer:code-path-tracer:${{ github.ref_name }}")
             }
             ```
             

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+tmp/
+
 # Gradle
 .gradle/
 build/

--- a/build.gradle
+++ b/build.gradle
@@ -38,7 +38,7 @@ allprojects {
     project.group = "io.github.takahirom.codepathtracer"
     mavenPublishing {
       publishToMavenCentral(com.vanniktech.maven.publish.SonatypeHost.CENTRAL_PORTAL)
-      signAllPublications()
+//      signAllPublications()
     }
 
     plugins.withId('maven-publish') {

--- a/build.gradle
+++ b/build.gradle
@@ -38,7 +38,7 @@ allprojects {
     project.group = "io.github.takahirom.codepathtracer"
     mavenPublishing {
       publishToMavenCentral(com.vanniktech.maven.publish.SonatypeHost.CENTRAL_PORTAL)
-//      signAllPublications()
+      signAllPublications()
     }
 
     plugins.withId('maven-publish') {

--- a/code-path-tracer/build.gradle.kts
+++ b/code-path-tracer/build.gradle.kts
@@ -20,3 +20,14 @@ dependencies {
   
   testImplementation(libs.junit)
 }
+
+// JAR manifest configuration for runtime agent usage
+// Note: No Premain-Class needed as we use ByteBuddyAgent.install() at runtime
+tasks.jar {
+  manifest {
+    attributes(
+      "Can-Retransform-Classes" to "true",  
+      "Can-Redefine-Classes" to "true"
+    )
+  }
+}

--- a/code-path-tracer/src/main/kotlin/io/github/takahirom/codepathtracer/CodePathTracerAgent.kt
+++ b/code-path-tracer/src/main/kotlin/io/github/takahirom/codepathtracer/CodePathTracerAgent.kt
@@ -181,12 +181,14 @@ object CodePathTracerAgent {
                     // Return the class unchanged for Robolectric classes
                     builder
                 } else {
-                    // Apply normal transformation for non-Robolectric classes
-                    builder.visit(
-                        net.bytebuddy.asm.Advice.to(MethodTraceAdvice::class.java)
-                            .on(ElementMatchers.any<net.bytebuddy.description.method.MethodDescription>()
-                                .and(ElementMatchers.not(ElementMatchers.isTypeInitializer())))
-                    )
+                    // Apply ForAdvice transformation for non-Robolectric classes  
+                    AgentBuilder.Transformer.ForAdvice()
+                        .advice(
+                            ElementMatchers.any<net.bytebuddy.description.method.MethodDescription>()
+                                .and(ElementMatchers.not(ElementMatchers.isTypeInitializer())),
+                            MethodTraceAdvice::class.java.name
+                        )
+                        .transform(builder, typeDescription, classLoader, module)
                 }
             }
     }

--- a/code-path-tracer/src/main/kotlin/io/github/takahirom/codepathtracer/CodePathTracerAgent.kt
+++ b/code-path-tracer/src/main/kotlin/io/github/takahirom/codepathtracer/CodePathTracerAgent.kt
@@ -5,9 +5,7 @@ import net.bytebuddy.description.NamedElement
 import net.bytebuddy.description.type.TypeDescription
 import net.bytebuddy.matcher.ElementMatchers
 import net.bytebuddy.utility.JavaModule
-import java.io.File
 import java.lang.instrument.Instrumentation
-import java.nio.file.Files
 
 // DEBUG flag moved to CodePathTracer.DEBUG
 
@@ -42,8 +40,7 @@ object CodePathTracerAgent {
 
         try {
             val instrumentation = net.bytebuddy.agent.ByteBuddyAgent.install()
-
-            val agentBuilder = createAgentBuilder(config, instrumentation)
+            val agentBuilder = createAgentBuilder()
 
             resettableTransformer = agentBuilder
                 .installOnByteBuddyAgent()
@@ -83,25 +80,7 @@ object CodePathTracerAgent {
 
 
     @Suppress("NewApi")
-    private fun createAgentBuilder(@Suppress("UNUSED_PARAMETER") config: CodePathTracer.Config, instrumentation: Instrumentation): AgentBuilder {
-        val temp = Files.createTempDirectory("code-path-tracer-").toFile()
-        try {
-            injectRequiredClasses(temp, instrumentation)
-        } finally {
-            // Clean up temporary directory and its contents for security
-            temp.deleteRecursively()
-        }
-        return createAgentBuilderInstance()
-    }
-
-    private fun injectRequiredClasses(@Suppress("UNUSED_PARAMETER") temp: File, @Suppress("UNUSED_PARAMETER") instrumentation: Instrumentation) {
-        // Always skip Bootstrap injection to avoid AccessError with sandbox environments
-        if (CodePathTracer.DEBUG) {
-            println("[MethodTrace] Skipping Bootstrap injection to avoid AccessError with sandbox environments")
-        }
-    }
-
-    private fun createAgentBuilderInstance(): AgentBuilder {
+    private fun createAgentBuilder(): AgentBuilder {
         return AgentBuilder.Default()
             .with(DebugListener())
             .disableClassFormatChanges()

--- a/code-path-tracer/src/main/kotlin/io/github/takahirom/codepathtracer/CodePathTracerAgent.kt
+++ b/code-path-tracer/src/main/kotlin/io/github/takahirom/codepathtracer/CodePathTracerAgent.kt
@@ -47,7 +47,6 @@ object CodePathTracerAgent {
 
             resettableTransformer = agentBuilder
                 .installOnByteBuddyAgent()
-            if (CodePathTracer.DEBUG) println("[MethodTrace] AgentBuilder installed on instrumentation")
             
             // Auto-detect and retransform already loaded classes that might need tracing
             if (config.autoRetransform) {
@@ -71,7 +70,6 @@ object CodePathTracerAgent {
             }
 
             isInitialized = true
-            if (CodePathTracer.DEBUG) println("[MethodTrace] Agent initialization completed successfully")
 
         } catch (e: Exception) {
             if (CodePathTracer.DEBUG) {
@@ -86,7 +84,6 @@ object CodePathTracerAgent {
 
     @Suppress("NewApi")
     private fun createAgentBuilder(config: CodePathTracer.Config, instrumentation: Instrumentation): AgentBuilder {
-        if (CodePathTracer.DEBUG) println("[MethodTrace] createAgentBuilder called with config: $config")
         val temp = Files.createTempDirectory("code-path-tracer-").toFile()
         try {
             injectRequiredClasses(temp, instrumentation)
@@ -265,15 +262,12 @@ object CodePathTracerAgent {
      */
     @Synchronized
     fun reset() {
-        if (CodePathTracer.DEBUG) println("[MethodTrace] Resetting configuration")
         config = null
         
         // Clean up ThreadLocal variables to prevent memory leaks
         try {
             MethodTraceAdvice.cleanup()
-            if (CodePathTracer.DEBUG) println("[MethodTrace] ThreadLocal variables cleaned up")
         } catch (e: Exception) {
-            if (CodePathTracer.DEBUG) println("[MethodTrace] ThreadLocal cleanup failed: ${e.message}")
         }
         
         // Reset the ByteBuddy transformer
@@ -290,14 +284,12 @@ object CodePathTracerAgent {
                 }
             }
         } catch (e: Exception) {
-            if (CodePathTracer.DEBUG) println("[MethodTrace] ByteBuddy transformer reset failed: ${e.message}")
         }
         
         // Force reset initialization state to allow re-initialization 
         isInitialized = false
         resettableTransformer = null
         
-        if (CodePathTracer.DEBUG) println("[MethodTrace] Agent reset completed - ready for re-initialization")
     }
 
 }

--- a/code-path-tracer/src/main/kotlin/io/github/takahirom/codepathtracer/CodePathTracerAgent.kt
+++ b/code-path-tracer/src/main/kotlin/io/github/takahirom/codepathtracer/CodePathTracerAgent.kt
@@ -162,16 +162,14 @@ object CodePathTracerAgent {
         // In Robolectric sandbox environments, exclude problematic android classes that cause AccessError
         // These are classes that Robolectric's Reflectors cannot access due to ClassLoader isolation
         return if (isRobolectricSandboxEnvironment()) {
-            println("[MethodTrace] Robolectric sandbox detected - excluding problematic android classes to avoid AccessError")
             basePackages + listOf(
-                "android.view.View\$AttachInfo",                           // View hierarchy access issues
-                "android.hardware.display.ColorDisplayManager",           // Display manager access issues  
-                "android.hardware.display.",                               // All display hardware classes
-                "android.view.ViewRootImpl",                              // View root implementation issues
-                "android.view.Choreographer"                              // Animation/drawing coordination issues
+                "android.view.View\$AttachInfo",
+                "android.hardware.display.ColorDisplayManager",
+                "android.hardware.display.",
+                "android.view.ViewRootImpl",
+                "android.view.Choreographer"
             )
         } else {
-            println("[MethodTrace] Normal environment - all android.* packages will be traced")
             basePackages
         }
     }
@@ -253,33 +251,11 @@ object CodePathTracerAgent {
     
     private fun isRobolectricSandboxEnvironment(): Boolean {
         return try {
-            // Check if we're currently running inside a Robolectric sandbox
             val contextClassLoader = Thread.currentThread().contextClassLoader
-            if (contextClassLoader != null) {
-                val classLoaderName = contextClassLoader.toString()
-                println("[MethodTrace] Checking ClassLoader: $classLoaderName")
-                if (classLoaderName.contains("AndroidSandbox") || 
-                    classLoaderName.contains("SdkSandboxClassLoader")) {
-                    println("[MethodTrace] Robolectric sandbox ClassLoader detected")
-                    return true
-                }
-            }
-            
-            // Check stack trace for active Robolectric sandbox execution
-            val stackTrace = Thread.currentThread().stackTrace
-            for (frame in stackTrace) {
-                if (frame.className.contains("AndroidSandbox") ||
-                    frame.className.contains("SandboxTestRunner") ||
-                    frame.className.contains("robolectric.internal.bytecode.Sandbox")) {
-                    println("[MethodTrace] Robolectric sandbox in stack trace: ${frame.className}")
-                    return true
-                }
-            }
-            
-            println("[MethodTrace] No Robolectric sandbox detected")
-            false
+            contextClassLoader?.toString()?.let { classLoaderName ->
+                classLoaderName.contains("AndroidSandbox") || classLoaderName.contains("SdkSandboxClassLoader")
+            } ?: false
         } catch (e: Exception) {
-            println("[MethodTrace] Error in sandbox detection: ${e.message}")
             false
         }
     }

--- a/code-path-tracer/src/main/kotlin/io/github/takahirom/codepathtracer/CodePathTracerAgent.kt
+++ b/code-path-tracer/src/main/kotlin/io/github/takahirom/codepathtracer/CodePathTracerAgent.kt
@@ -206,7 +206,13 @@ object CodePathTracerAgent {
         "sun.",
         "com.sun.",
         "android.util.DebugUtils",
-        "io.github.takahirom.codepathtracer."
+        "io.github.takahirom.codepathtracer.",
+        // IntelliJ IDEA debugger agent classes
+        "com.intellij.rt.debugger.",
+        "com.intellij.rt.execution.",
+        // JetBrains debugger and profiler agents
+        "com.jetbrains.jps.",
+        "org.jetbrains.jps."
     )
     
     /**

--- a/code-path-tracer/src/main/kotlin/io/github/takahirom/codepathtracer/CodePathTracerAgent.kt
+++ b/code-path-tracer/src/main/kotlin/io/github/takahirom/codepathtracer/CodePathTracerAgent.kt
@@ -83,7 +83,7 @@ object CodePathTracerAgent {
 
 
     @Suppress("NewApi")
-    private fun createAgentBuilder(config: CodePathTracer.Config, instrumentation: Instrumentation): AgentBuilder {
+    private fun createAgentBuilder(@Suppress("UNUSED_PARAMETER") config: CodePathTracer.Config, instrumentation: Instrumentation): AgentBuilder {
         val temp = Files.createTempDirectory("code-path-tracer-").toFile()
         try {
             injectRequiredClasses(temp, instrumentation)

--- a/code-path-tracer/src/main/kotlin/io/github/takahirom/codepathtracer/MethodTraceAdvice.kt
+++ b/code-path-tracer/src/main/kotlin/io/github/takahirom/codepathtracer/MethodTraceAdvice.kt
@@ -88,16 +88,5 @@ class MethodTraceAdvice {
             depthCounter.remove()
             isTracing.remove()
         }
-        
-        /**
-         * Force cleanup all ThreadLocal variables across all threads
-         * Useful for test environments where coroutines might leave traces
-         */
-        @JvmStatic
-        fun forceCleanupAllThreads() {
-            cleanup()
-            // Force GC to clean up any remaining ThreadLocal references
-            System.gc()
-        }
     }
 }

--- a/code-path-tracer/src/main/kotlin/io/github/takahirom/codepathtracer/MethodTraceAdvice.kt
+++ b/code-path-tracer/src/main/kotlin/io/github/takahirom/codepathtracer/MethodTraceAdvice.kt
@@ -87,5 +87,16 @@ class MethodTraceAdvice {
             depthCounter.remove()
             isTracing.remove()
         }
+        
+        /**
+         * Force cleanup all ThreadLocal variables across all threads
+         * Useful for test environments where coroutines might leave traces
+         */
+        @JvmStatic
+        fun forceCleanupAllThreads() {
+            cleanup()
+            // Force GC to clean up any remaining ThreadLocal references
+            System.gc()
+        }
     }
 }

--- a/code-path-tracer/src/main/kotlin/io/github/takahirom/codepathtracer/MethodTraceAdvice.kt
+++ b/code-path-tracer/src/main/kotlin/io/github/takahirom/codepathtracer/MethodTraceAdvice.kt
@@ -1,10 +1,11 @@
 package io.github.takahirom.codepathtracer
 
 /**
- * Static class for ByteBuddy Advice
+ * ByteBuddy advice for method tracing
  */
 class MethodTraceAdvice {
     companion object {
+        
         private val depthCounter = ThreadLocal.withInitial { 0 }
         private val isTracing = ThreadLocal.withInitial { false }
         

--- a/gradle.properties
+++ b/gradle.properties
@@ -11,7 +11,7 @@ android.useAndroidX=true
 
 # Publishing
 # Default version - will be overridden by environment variable in CI
-VERSION_NAME=0.1.0-dev
+VERSION_NAME=0.1.0-SNAPSHOT
 GROUP=io.github.takahirom.codepathtracer
 
 SONATYPE_AUTOMATIC_RELEASE=true

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -4,7 +4,7 @@
 
 [versions]
 # https://github.com/raphw/byte-buddy/?tab=readme-ov-file#java-version-compatibility
-byteBuddy = "1.10.19"
+byteBuddy = "1.15.11"
 junit = "4.13.2"
 kotlin = "1.9.22"
 kotlinxDatetime = "0.6.1"

--- a/sample-jvm/src/test/kotlin/io/github/takahirom/codepathtracersample/JvmMethodTraceTest.kt
+++ b/sample-jvm/src/test/kotlin/io/github/takahirom/codepathtracersample/JvmMethodTraceTest.kt
@@ -62,26 +62,12 @@ class JvmMethodTraceTest {
         println("Complex calculation result: $result3")
         assert(result3 == 28) // (5 + 3) * 2 + 12
         
-        // Check if Rule captured any events
-        println("📊 Rule captured ${capturedEvents.size} total trace events:")
-        capturedEvents.take(10).forEach { event ->
-            println("  - $event")
-        }
-        if (capturedEvents.size > 10) {
-            println("  ... and ${capturedEvents.size - 10} more events")
-        }
+        // Verify tracing is working
+        println("Rule captured ${capturedEvents.size} events")
+        assert(capturedEvents.isNotEmpty()) { "Expected trace events" }
         
-        // Assert that tracing is actually working
-        assert(capturedEvents.isNotEmpty()) { 
-            "🚨 TRACING NOT WORKING: Expected Rule to capture trace events but got ${capturedEvents.size}" 
-        }
-        
-        // Verify we captured events from TestCalculator
         val calculatorEvents = capturedEvents.filter { it.className.contains("TestCalculator") }
-        println("📊 TestCalculator events: ${calculatorEvents.size}")
-        assert(calculatorEvents.isNotEmpty()) {
-            "🚨 Expected to capture TestCalculator events but got ${calculatorEvents.size}"
-        }
+        assert(calculatorEvents.isNotEmpty()) { "Expected TestCalculator events" }
         
         println("=== Business logic test completed ===")
     }

--- a/sample-robolectric/src/test/kotlin/io/github/takahirom/codepathtracersample/CodePathVerificationTest.kt
+++ b/sample-robolectric/src/test/kotlin/io/github/takahirom/codepathtracersample/CodePathVerificationTest.kt
@@ -18,10 +18,25 @@ class CodePathVerificationTest {
         println("==========================================")
         
         val capturedEvents = mutableListOf<TraceEvent>()
+        val applicationEvents = mutableListOf<TraceEvent>()
+        val frameworkEvents = mutableListOf<TraceEvent>()
+        val libraryEvents = mutableListOf<TraceEvent>()
         
         codePathTrace({
             filter { event ->
                 capturedEvents.add(event)
+                
+                when {
+                    event.className.startsWith("io.github.takahirom.codepathtracersample") -> {
+                        applicationEvents.add(event)
+                    }
+                    event.className.startsWith("android.view") || event.className.startsWith("android.widget") -> {
+                        frameworkEvents.add(event)
+                    }
+                    event.className.startsWith("androidx.") || event.className.startsWith("kotlin.") -> {
+                        libraryEvents.add(event)
+                    }
+                }
                 true
             }
         }) {
@@ -29,11 +44,61 @@ class CodePathVerificationTest {
             val controller = Robolectric.buildActivity(MainActivity::class.java)
             val activity = controller.create().get()
             
+            // Try to trigger some view operations
+            activity.findViewById<android.widget.Button>(activity.getButtonId())?.let { button ->
+                println("Button found, performing click...")
+                button.performClick()
+            }
+            
             assert(activity != null)
             println("Activity creation completed")
         }
         
-        println("\nTotal events captured: ${capturedEvents.size}")
+        println("\n=== Event Summary ===")
+        println("Total events captured: ${capturedEvents.size}")
+        println("Application events: ${applicationEvents.size}")
+        println("Framework events: ${frameworkEvents.size}")
+        println("Library events: ${libraryEvents.size}")
+        
+        // Verify that we captured at least one event from each category
+        assert(applicationEvents.isNotEmpty()) { "Expected to capture at least one application event" }
+        assert(frameworkEvents.isNotEmpty()) { "Expected to capture at least one framework event" }
+        
+        // Verify specific application classes are traced
+        assert(applicationEvents.any { it.className.contains("MainActivity") }) { 
+            "Expected to capture MainActivity events" 
+        }
+        assert(applicationEvents.any { it.className.contains("CodePathVerificationTest") }) { 
+            "Expected to capture test class events" 
+        }
+        
+        // Verify specific framework classes are traced
+        assert(frameworkEvents.any { it.className.startsWith("android.view.View") }) { 
+            "Expected to capture android.view.View events" 
+        }
+        assert(frameworkEvents.any { it.className.startsWith("android.widget.") }) { 
+            "Expected to capture android.widget events" 
+        }
+        
+        // Verify library events if present
+        if (libraryEvents.isNotEmpty()) {
+            assert(libraryEvents.any { it.className.startsWith("androidx.") }) { 
+                "Expected androidx events if library events exist" 
+            }
+        }
+        
+        // Verify total event count is reasonable
+        assert(capturedEvents.size > 100) { 
+            "Expected substantial number of events, got ${capturedEvents.size}" 
+        }
+        
+        // Verify event distribution is reasonable
+        val totalEvents = applicationEvents.size + frameworkEvents.size + libraryEvents.size
+        assert(totalEvents > 0) { "No categorized events found" }
+        assert(frameworkEvents.size > applicationEvents.size) { 
+            "Expected more framework events than application events" 
+        }
+        
         println("Verification completed - traces are working!")
     }
     
@@ -65,6 +130,23 @@ class CodePathVerificationTest {
         }
         
         println("\nTotal click-related events captured: ${capturedEvents.size}")
+        
+        // Verify click events were captured
+        assert(capturedEvents.isNotEmpty()) { "Expected to capture click-related events" }
+        assert(capturedEvents.all { it.className.contains("MainActivity") }) { 
+            "All captured events should be from MainActivity" 
+        }
+        
+        // Verify we have the expected event types (at least one should be captured)
+        val enterEvents = capturedEvents.filterIsInstance<TraceEvent.Enter>()
+        val exitEvents = capturedEvents.filterIsInstance<TraceEvent.Exit>()
+        assert(enterEvents.isNotEmpty() || exitEvents.isNotEmpty()) { 
+            "Expected at least one Enter or Exit event" 
+        }
+        
+        // Verify event consistency
+        assert(capturedEvents.isNotEmpty()) { "Expected at least one event" }
+        
         println("Click event tracing verification completed!")
     }
 }

--- a/sample-robolectric/src/test/kotlin/io/github/takahirom/codepathtracersample/CodePathVerificationTest.kt
+++ b/sample-robolectric/src/test/kotlin/io/github/takahirom/codepathtracersample/CodePathVerificationTest.kt
@@ -113,20 +113,24 @@ class CodePathVerificationTest {
         val controller = Robolectric.buildActivity(MainActivity::class.java)
         val activity = controller.create().start().resume().get()
         
-        println("\n🎯 Simulating button click with tracing...")
-        
-        codePathTrace({
-            filter { event ->
-                if (event.className.contains("MainActivity")) {
-                    capturedEvents.add(event)
-                    println("${if (event is TraceEvent.Enter) "→" else "←"} ${event.shortClassName}.${event.methodName}")
-                    true
-                } else false
+        try {
+            println("\n🎯 Simulating button click with tracing...")
+            
+            codePathTrace({
+                filter { event ->
+                    if (event.className.contains("MainActivity")) {
+                        capturedEvents.add(event)
+                        println("${if (event is TraceEvent.Enter) "→" else "←"} ${event.shortClassName}.${event.methodName}")
+                        true
+                    } else false
+                }
+            }) {
+                val button = activity.findViewById<android.widget.Button>(activity.getButtonId())
+                button.performClick()
+                println("Button click simulation completed")
             }
-        }) {
-            val button = activity.findViewById<android.widget.Button>(activity.getButtonId())
-            button.performClick()
-            println("Button click simulation completed")
+        } finally {
+            controller.pause().stop().destroy()
         }
         
         println("\nTotal click-related events captured: ${capturedEvents.size}")

--- a/sample-robolectric/src/test/kotlin/io/github/takahirom/codepathtracersample/CodePathVerificationTest.kt
+++ b/sample-robolectric/src/test/kotlin/io/github/takahirom/codepathtracersample/CodePathVerificationTest.kt
@@ -118,7 +118,7 @@ class CodePathVerificationTest {
             
             codePathTrace({
                 filter { event ->
-                    if (event.className.contains("MainActivity")) {
+                    if (event.className.contains("MainActivity") && event.methodName.contains("handleButtonClick")) {
                         capturedEvents.add(event)
                         println("${if (event is TraceEvent.Enter) "→" else "←"} ${event.shortClassName}.${event.methodName}")
                         true

--- a/sample-robolectric/src/test/kotlin/io/github/takahirom/codepathtracersample/CodePathVerificationTest.kt
+++ b/sample-robolectric/src/test/kotlin/io/github/takahirom/codepathtracersample/CodePathVerificationTest.kt
@@ -57,8 +57,9 @@ class CodePathVerificationTest {
         
         println("\nTotal events captured: ${capturedEvents.size}")
         
-        // Basic verification
-        assert(capturedEvents.isNotEmpty()) { "Expected to capture events" }
+        // Verify one event from each category
+        assert(applicationEvents.isNotEmpty()) { "Expected application events" }
+        assert(frameworkEvents.isNotEmpty()) { "Expected framework events" }
         assert(applicationEvents.any { it.className.contains("MainActivity") }) { 
             "Expected MainActivity events" 
         }

--- a/sample-robolectric/src/test/kotlin/io/github/takahirom/codepathtracersample/CodePathVerificationTest.kt
+++ b/sample-robolectric/src/test/kotlin/io/github/takahirom/codepathtracersample/CodePathVerificationTest.kt
@@ -55,49 +55,12 @@ class CodePathVerificationTest {
             println("Activity creation completed")
         }
         
-        println("\n=== Event Summary ===")
-        println("Total events captured: ${capturedEvents.size}")
-        println("Application events: ${applicationEvents.size}")
-        println("Framework events: ${frameworkEvents.size}")
-        println("Library events: ${libraryEvents.size}")
+        println("\nTotal events captured: ${capturedEvents.size}")
         
-        // Verify that we captured at least one event from each category
-        assert(applicationEvents.isNotEmpty()) { "Expected to capture at least one application event" }
-        assert(frameworkEvents.isNotEmpty()) { "Expected to capture at least one framework event" }
-        
-        // Verify specific application classes are traced
+        // Basic verification
+        assert(capturedEvents.isNotEmpty()) { "Expected to capture events" }
         assert(applicationEvents.any { it.className.contains("MainActivity") }) { 
-            "Expected to capture MainActivity events" 
-        }
-        assert(applicationEvents.any { it.className.contains("CodePathVerificationTest") }) { 
-            "Expected to capture test class events" 
-        }
-        
-        // Verify specific framework classes are traced
-        assert(frameworkEvents.any { it.className.startsWith("android.view.View") }) { 
-            "Expected to capture android.view.View events" 
-        }
-        assert(frameworkEvents.any { it.className.startsWith("android.widget.") }) { 
-            "Expected to capture android.widget events" 
-        }
-        
-        // Verify library events if present
-        if (libraryEvents.isNotEmpty()) {
-            assert(libraryEvents.any { it.className.startsWith("androidx.") }) { 
-                "Expected androidx events if library events exist" 
-            }
-        }
-        
-        // Verify total event count is reasonable
-        assert(capturedEvents.size > 100) { 
-            "Expected substantial number of events, got ${capturedEvents.size}" 
-        }
-        
-        // Verify event distribution is reasonable
-        val totalEvents = applicationEvents.size + frameworkEvents.size + libraryEvents.size
-        assert(totalEvents > 0) { "No categorized events found" }
-        assert(frameworkEvents.size > applicationEvents.size) { 
-            "Expected more framework events than application events" 
+            "Expected MainActivity events" 
         }
         
         println("Verification completed - traces are working!")
@@ -133,23 +96,8 @@ class CodePathVerificationTest {
             }
         }
         
-        println("\nTotal click-related events captured: ${capturedEvents.size}")
-        
-        // Verify click events were captured
-        assert(capturedEvents.isNotEmpty()) { "Expected to capture click-related events" }
-        assert(capturedEvents.all { it.className.contains("MainActivity") }) { 
-            "All captured events should be from MainActivity" 
-        }
-        
-        // Verify we have the expected event types (at least one should be captured)
-        val enterEvents = capturedEvents.filterIsInstance<TraceEvent.Enter>()
-        val exitEvents = capturedEvents.filterIsInstance<TraceEvent.Exit>()
-        assert(enterEvents.isNotEmpty() || exitEvents.isNotEmpty()) { 
-            "Expected at least one Enter or Exit event" 
-        }
-        
-        // Verify event consistency
-        assert(capturedEvents.isNotEmpty()) { "Expected at least one event" }
+        println("\nClick events captured: ${capturedEvents.size}")
+        assert(capturedEvents.isNotEmpty()) { "Expected click events" }
         
         println("Click event tracing verification completed!")
     }

--- a/sample-robolectric/src/test/kotlin/io/github/takahirom/codepathtracersample/RobolectricByteBuddyTest.kt
+++ b/sample-robolectric/src/test/kotlin/io/github/takahirom/codepathtracersample/RobolectricByteBuddyTest.kt
@@ -14,7 +14,6 @@ class RobolectricByteBuddyTest {
     
     @Test
     fun testByteBuddyWorksInRobolectric() {
-        println("🔍 Testing ByteBuddy in Robolectric environment")
         
         val capturedEvents = mutableListOf<TraceEvent>()
         
@@ -39,17 +38,11 @@ class RobolectricByteBuddyTest {
             }
         }
         
-        println("Total events captured: ${capturedEvents.size}")
-        if (capturedEvents.isNotEmpty()) {
-            println("✅ ByteBuddy works in Robolectric!")
-        } else {
-            println("❌ ByteBuddy does NOT work in Robolectric")
-        }
+        assert(capturedEvents.isNotEmpty()) { "ByteBuddy should work in Robolectric" }
     }
     
     @Test
     fun testMainActivityDirectly() {
-        println("🔍 Testing MainActivity directly (no Robolectric controller)")
         
         val capturedEvents = mutableListOf<TraceEvent>()
         val mainActivityEvents = mutableListOf<TraceEvent>()
@@ -81,16 +74,6 @@ class RobolectricByteBuddyTest {
             }
         }
         
-        println("Total events captured: ${capturedEvents.size}")
-        println("MainActivity events captured: ${mainActivityEvents.size}")
-        
-        if (mainActivityEvents.isNotEmpty()) {
-            println("✅ MainActivity methods are traceable!")
-            mainActivityEvents.forEach { event ->
-                println("  - ${event.className}.${event.methodName}")
-            }
-        } else {
-            println("❌ MainActivity methods are NOT traceable")
-        }
+        assert(mainActivityEvents.isNotEmpty()) { "MainActivity methods should be traceable" }
     }
 }

--- a/sample-robolectric/src/test/kotlin/io/github/takahirom/codepathtracersample/RobolectricByteBuddyTest.kt
+++ b/sample-robolectric/src/test/kotlin/io/github/takahirom/codepathtracersample/RobolectricByteBuddyTest.kt
@@ -1,0 +1,96 @@
+package io.github.takahirom.codepathtracersample
+
+import io.github.takahirom.codepathtracer.CodePathTracer
+import io.github.takahirom.codepathtracer.TraceEvent
+import io.github.takahirom.codepathtracer.codePathTrace
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [34])
+class RobolectricByteBuddyTest {
+    
+    @Test
+    fun testByteBuddyWorksInRobolectric() {
+        println("🔍 Testing ByteBuddy in Robolectric environment")
+        
+        val capturedEvents = mutableListOf<TraceEvent>()
+        
+        codePathTrace(CodePathTracer.Config(
+            autoRetransform = false,
+            filter = { event ->
+                if (event.className.contains("MainActivity")) {
+                    capturedEvents.add(event)
+                    println("CAPTURED: ${event.className}.${event.methodName}")
+                    true
+                } else false
+            }
+        )) {
+            try {
+                println("Creating MainActivity instance...")
+                val mainActivity = MainActivity()
+                
+                println("Calling handleButtonClick...")
+                mainActivity.handleButtonClick()
+            } catch (e: Exception) {
+                println("MainActivity creation failed: ${e.message} (expected without Android context)")
+            }
+        }
+        
+        println("Total events captured: ${capturedEvents.size}")
+        if (capturedEvents.isNotEmpty()) {
+            println("✅ ByteBuddy works in Robolectric!")
+        } else {
+            println("❌ ByteBuddy does NOT work in Robolectric")
+        }
+    }
+    
+    @Test
+    fun testMainActivityDirectly() {
+        println("🔍 Testing MainActivity directly (no Robolectric controller)")
+        
+        val capturedEvents = mutableListOf<TraceEvent>()
+        val mainActivityEvents = mutableListOf<TraceEvent>()
+        
+        codePathTrace(CodePathTracer.Config(
+            autoRetransform = false,
+            filter = { event ->
+                println("DEBUG: Event captured - ${event.className}.${event.methodName}")
+                capturedEvents.add(event)
+                
+                if (event.className.contains("MainActivity")) {
+                    mainActivityEvents.add(event)
+                    println("MAIN_ACTIVITY: ${if (event is TraceEvent.Enter) "→" else "←"} ${event.shortClassName}.${event.methodName}")
+                }
+                true
+            }
+        )) {
+            try {
+                println("Creating MainActivity instance directly...")
+                val mainActivity = MainActivity()
+                
+                println("Calling handleButtonClick...")
+                mainActivity.handleButtonClick()
+                
+                println("MainActivity test completed")
+            } catch (e: Exception) {
+                println("MainActivity creation failed: ${e.message}")
+                println("This is expected without Android context")
+            }
+        }
+        
+        println("Total events captured: ${capturedEvents.size}")
+        println("MainActivity events captured: ${mainActivityEvents.size}")
+        
+        if (mainActivityEvents.isNotEmpty()) {
+            println("✅ MainActivity methods are traceable!")
+            mainActivityEvents.forEach { event ->
+                println("  - ${event.className}.${event.methodName}")
+            }
+        } else {
+            println("❌ MainActivity methods are NOT traceable")
+        }
+    }
+}

--- a/sample-robolectric/src/test/kotlin/io/github/takahirom/codepathtracersample/RobolectricMethodTraceTest.kt
+++ b/sample-robolectric/src/test/kotlin/io/github/takahirom/codepathtracersample/RobolectricMethodTraceTest.kt
@@ -28,23 +28,27 @@ class RobolectricMethodTraceTest {
         // Create Activity Controller
         val controller = Robolectric.buildActivity(MainActivity::class.java)
         
-        // Lifecycle: Create
-        println("Creating activity...")
-        val activity = controller.create().get()
-        
-        // Verify activity is created
-        assert(activity != null)
-        println("Activity created successfully")
-        
-        // Lifecycle: Start
-        println("Starting activity...")
-        controller.start()
-        
-        // Lifecycle: Resume
-        println("Resuming activity...")
-        controller.resume()
-        
-        println("=== Activity lifecycle test completed ===")
+        try {
+            // Lifecycle: Create
+            println("Creating activity...")
+            val activity = controller.create().get()
+            
+            // Verify activity is created
+            assert(activity != null)
+            println("Activity created successfully")
+            
+            // Lifecycle: Start
+            println("Starting activity...")
+            controller.start()
+            
+            // Lifecycle: Resume
+            println("Resuming activity...")
+            controller.resume()
+            
+            println("=== Activity lifecycle test completed ===")
+        } finally {
+            controller.pause().stop().destroy()
+        }
     }
     
     @Test
@@ -81,8 +85,12 @@ class RobolectricMethodTraceTest {
         val controller = Robolectric.buildActivity(MainActivity::class.java)
         val activity = controller.create().start().resume().get()
         
-        val button = activity.findViewById<android.widget.Button>(activity.getButtonId())
-        button.performClick()
+        try {
+            val button = activity.findViewById<android.widget.Button>(activity.getButtonId())
+            button.performClick()
+        } finally {
+            controller.pause().stop().destroy()
+        }
     }
 
     @Test


### PR DESCRIPTION
# What
Fixed IllegalAccessError that occurred when code-path-tracer's ByteBuddy instrumentation conflicted with Robolectric's AndroidSandbox ClassLoader, while preserving Android framework class tracing capabilities.

# Why
- Robolectric's dynamically generated Reflector classes were causing IllegalAccessError when instrumented by ByteBuddy
- Previous workarounds like excluding entire Android framework packages defeated the library's core value proposition
- Test interference between multiple test methods was causing flaky test results

Key changes:
- Added ClassLoader detection to skip instrumentation for Robolectric AndroidSandbox classes
- Enhanced agent reset functionality to prevent test interference
- Consolidated package exclusion logic and improved test assertions
- Maintained full Android framework class tracing while avoiding Robolectric conflicts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a utility method to force cleanup of thread-local variables for method tracing.
  * Introduced Robolectric-based tests to verify ByteBuddy instrumentation and method tracing in test environments.

* **Bug Fixes**
  * Improved activity lifecycle cleanup in Robolectric tests to prevent resource leaks.

* **Refactor**
  * Simplified agent initialization and class injection logic, centralizing package ignore rules and enhancing debug output.

* **Tests**
  * Enhanced test coverage and event validation in both JVM and Robolectric test suites, including more granular event categorization and focused event assertions.

* **Chores**
  * Updated Byte Buddy dependency version.
  * Updated default version name for publishing.
  * Updated `.gitignore` to exclude the `tmp/` directory.
  * Updated GitHub Release example dependency notation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->