### PR TITLE
Remove unnecessary println statements from test files

### DIFF
--- a/sample-jvm/src/test/kotlin/io/github/takahirom/codepathtracersample/ContextExitDuplicationTest.kt
+++ b/sample-jvm/src/test/kotlin/io/github/takahirom/codepathtracersample/ContextExitDuplicationTest.kt
@@ -24,14 +24,10 @@ class ContextExitDuplicationTest {
     
     @Test
     fun testContextExitTrackingWithDuplicationPrevention() {
-        println("=== Testing context exit tracking and duplication prevention ===")
-        
         val output = captureOutput {
             val test = DuplicationTestHierarchy()
             test.a()  // a -> b1, a -> b2
         }
-        
-        println("=== Test completed - A should appear only once for enter and once for exit ===")
         
         // Extract trace lines (lines with → or ←) - preserve indentation!
         val traceLines = output.lines()
@@ -101,13 +97,9 @@ class ContextExitDuplicationTest {
     
     @Test
     fun testNestedContextExitTracking() {
-        println("=== Testing nested context exit tracking ===")
-        
         // This test demonstrates that the current rule filters b1/b2, not inner methods
         val test = NestedTestHierarchy()
         test.outer()  // outer -> middle -> inner (no output because filter doesn't match)
-        
-        println("=== Nested test completed ===")
         
         // Since the current rule filters b1/b2 and NestedTestHierarchy has outer/middle/inner,
         // no trace output is expected. This test verifies the methods run without error.
@@ -121,32 +113,29 @@ class ContextExitDuplicationTest {
 
 class DuplicationTestHierarchy {
     fun a() {
-        println("Executing a")
         b1()
         b2()
     }
     
     fun b1() {
-        println("Executing b1")
+        // Method implementation
     }
     
     fun b2() {
-        println("Executing b2") 
+        // Method implementation
     }
 }
 
 class NestedTestHierarchy {
     fun outer() {
-        println("Executing outer")
         middle()
     }
     
     fun middle() {
-        println("Executing middle")
         inner()
     }
     
     fun inner() {
-        println("Executing inner")
+        // Method implementation
     }
 }

--- a/sample-jvm/src/test/kotlin/io/github/takahirom/codepathtracersample/HierarchicalContextActualTest.kt
+++ b/sample-jvm/src/test/kotlin/io/github/takahirom/codepathtracersample/HierarchicalContextActualTest.kt
@@ -19,16 +19,12 @@ class HierarchicalContextActualTest {
     
     @Test
     fun testHierarchicalContextWithRealTracing() {
-        println("=== Testing hierarchical context with actual tracing ===")
-        
         val output = captureOutput {
             val calculator = HierarchicalCalculator()
             // This should create a call chain: testHierarchicalContextWithRealTracing -> complexCalculation -> add
             val result = calculator.complexCalculation(5, 3)
             assertEquals("Result should be correct", 24, result)
         }
-        
-        println("=== Context test completed ===")
         
         // Verify trace output contains expected context hierarchy
         val traceLines = output.lines().filter { it.contains("→") || it.contains("←") }
@@ -53,21 +49,17 @@ class HierarchicalContextActualTest {
 
 class HierarchicalCalculator {
     fun add(a: Int, b: Int): Int {
-        println("Calculator: Adding $a + $b")
         return a + b
     }
     
     fun multiply(a: Int, b: Int): Int {
-        println("Calculator: Multiplying $a * $b")
         return a * b
     }
     
     fun complexCalculation(x: Int, y: Int): Int {
-        println("Calculator: Starting complex calculation with $x and $y")
         val sum = add(x, y)  // This should show context
         val doubled = multiply(sum, 2)
         val final = add(doubled, x + y)  // This should also show context
-        println("Calculator: Complex calculation complete")
         return final
     }
 }

--- a/sample-jvm/src/test/kotlin/io/github/takahirom/codepathtracersample/NestedContextTest.kt
+++ b/sample-jvm/src/test/kotlin/io/github/takahirom/codepathtracersample/NestedContextTest.kt
@@ -23,14 +23,10 @@ class NestedContextTest {
     
     @Test
     fun testSingleLevelNestedContext() {
-        println("=== Testing single level nested context (beforeContextSize=1) ===")
-        
         val output = captureOutput {
             val test = SimpleNestedHierarchy()
             test.outer()  // outer -> middle -> inner (only inner filtered, middle shown as context)
         }
-        
-        println("=== Nested context test completed ===")
         
         val traceLines = output.lines().filter { it.contains("→") || it.contains("←") }
         
@@ -70,14 +66,10 @@ class DeepNestedContextTest {
     
     @Test
     fun testMultiLevelNestedContext() {
-        println("=== Testing multi-level nested context (beforeContextSize=2) ===")
-        
         val output = captureOutput {
             val test = DeepNestHierarchy()
             test.outer()  // outer -> middle -> inner -> deepest
         }
-        
-        println("=== Deep nested context test completed ===")
         
         val traceLines = output.lines().filter { it.contains("→") || it.contains("←") }
         
@@ -104,37 +96,32 @@ class DeepNestedContextTest {
 
 class SimpleNestedHierarchy {
     fun outer() {
-        println("Executing outer")
         middle()
     }
     
     fun middle() {
-        println("Executing middle")
         inner()
     }
     
     fun inner() {
-        println("Executing inner")
+        // Method implementation
     }
 }
 
 class DeepNestHierarchy {
     fun outer() {
-        println("Executing outer")
         middle()
     }
     
     fun middle() {
-        println("Executing middle")
         inner()
     }
     
     fun inner() {
-        println("Executing inner")
         deepest()
     }
     
     fun deepest() {
-        println("Executing deepest")
+        // Method implementation
     }
 }


### PR DESCRIPTION
# What
Removed debugging println statements from nested context test files

# Why
- Clean up test output by removing unnecessary console logging  
- Focus tests on assertions rather than debug prints
- Improve test readability and maintainability