### PR TITLE
Fix depth accumulation bug in method tracing

### DIFF
--- a/code-path-tracer/src/main/kotlin/io/github/takahirom/codepathtracer/MethodTraceAdvice.kt
+++ b/code-path-tracer/src/main/kotlin/io/github/takahirom/codepathtracer/MethodTraceAdvice.kt
@@ -151,9 +151,6 @@ class MethodTraceAdvice {
                             )
                             println(config.formatter(contextEnterEvent))
                         }
-                        
-                        // Update filtered depth counter to account for shown context methods
-                        filteredDepthCounter.set(filteredDepthCounter.get() + methodsToShow.size)
                     }
                 }
                 

--- a/sample-jvm/src/test/kotlin/io/github/takahirom/codepathtracersample/ContextExitDuplicationTest.kt
+++ b/sample-jvm/src/test/kotlin/io/github/takahirom/codepathtracersample/ContextExitDuplicationTest.kt
@@ -33,6 +33,7 @@ class ContextExitDuplicationTest {
         val traceLines = output.lines()
             .filter { it.contains("→") || it.contains("←") }
         
+        
         // Verify expected output structure: should have exactly 6 trace lines
         assertEquals("Should have exactly 6 trace lines", 6, traceLines.size)
         

--- a/sample-jvm/src/test/kotlin/io/github/takahirom/codepathtracersample/DepthAccumulationBugTest.kt
+++ b/sample-jvm/src/test/kotlin/io/github/takahirom/codepathtracersample/DepthAccumulationBugTest.kt
@@ -45,6 +45,10 @@ class DepthAccumulationBugTest {
             testCalculator.add(i, 1)
         }
         
+        // Ensure we actually captured depth data before checking limits
+        assert(capturedDepths.isNotEmpty()) { 
+            "No depth data was captured - check your tracing filter configuration" 
+        }
         
         // The bug: depth should stay reasonable (< 20), not accumulate to 1000+
         // If the bug exists, later calls will have much higher depth values

--- a/sample-jvm/src/test/kotlin/io/github/takahirom/codepathtracersample/DepthAccumulationBugTest.kt
+++ b/sample-jvm/src/test/kotlin/io/github/takahirom/codepathtracersample/DepthAccumulationBugTest.kt
@@ -1,0 +1,74 @@
+package io.github.takahirom.codepathtracersample
+
+import io.github.takahirom.codepathtracer.CodePathTracer
+import io.github.takahirom.codepathtracer.DefaultFormatter
+import org.junit.Rule
+import org.junit.Test
+
+/**
+ * TDD Test to demonstrate and fix the depth accumulation bug
+ * 
+ * Problem: When using beforeContextSize > 0 with filter, depth values accumulate
+ * to very large numbers (e.g., 17395) instead of staying consistent.
+ */
+class DepthAccumulationBugTest {
+    
+    private val capturedDepths = mutableListOf<Int>()
+    
+    @get:Rule
+    val tracerWithBug = CodePathTracer.Builder()
+        .beforeContextSize(3)
+        .filter { event ->
+            // Only trace TestCalculator methods
+            event.className.contains("TestCalculator")
+        }
+        .formatter { event ->
+            // Capture depth values for assertion
+            capturedDepths.add(event.depth)
+            DefaultFormatter.format(event)
+        }
+        .asJUnitRule()
+    
+    @Test
+    fun testDepthShouldNotAccumulate() {
+        capturedDepths.clear()
+        
+        val testCalculator = TestCalculator("BugTest")
+        val fibCalculator = FibonacciTestCalculator()
+        
+        // Execute many recursive calls mixed with traced calls to trigger accumulation
+        repeat(50) { i ->
+            // Deep recursive calls that WILL pass the filter and create deep call stacks
+            fibCalculator.fibonacci(8 + (i % 3)) // Creates deep recursion with tracing
+            
+            // This call WILL also pass the filter - depth should NOT accumulate from previous calls
+            testCalculator.add(i, 1)
+        }
+        
+        
+        // The bug: depth should stay reasonable (< 20), not accumulate to 1000+
+        // If the bug exists, later calls will have much higher depth values
+        assert(capturedDepths.all { it < 100 }) { 
+            "Depth values should not exceed 100, but found: ${capturedDepths.filter { it >= 100 }}" 
+        }
+        
+        // Check if depth is growing unreasonably over time (sign of accumulation bug)
+        val firstHalfAvg = capturedDepths.take(capturedDepths.size / 2).average()
+        val secondHalfAvg = capturedDepths.drop(capturedDepths.size / 2).average()
+        
+        
+        // If there's a bug, second half will be much larger than first
+        val depthGrowth = secondHalfAvg - firstHalfAvg
+        assert(depthGrowth < 50) { 
+            "Depth should not grow significantly over time. Growth: $depthGrowth (first: $firstHalfAvg, second: $secondHalfAvg)" 
+        }
+    }
+}
+
+// Fibonacci calculator that WILL pass the TestCalculator filter (contains "TestCalculator" in name)
+class FibonacciTestCalculator {
+    fun fibonacci(n: Int): Long {
+        return if (n <= 1) n.toLong() else fibonacci(n - 1) + fibonacci(n - 2)
+    }
+}
+

--- a/sample-jvm/src/test/kotlin/io/github/takahirom/codepathtracersample/DepthAccumulationBugTest.kt
+++ b/sample-jvm/src/test/kotlin/io/github/takahirom/codepathtracersample/DepthAccumulationBugTest.kt
@@ -6,10 +6,8 @@ import org.junit.Rule
 import org.junit.Test
 
 /**
- * TDD Test to demonstrate and fix the depth accumulation bug
- * 
- * Problem: When using beforeContextSize > 0 with filter, depth values accumulate
- * to very large numbers (e.g., 17395) instead of staying consistent.
+ * Test for depth accumulation bug where depth values grow to very large numbers
+ * when using beforeContextSize > 0 with filter.
  */
 class DepthAccumulationBugTest {
     


### PR DESCRIPTION
# What
- Moved duplicate test file DepthBeforeContextIssueTest.kt to archived directory  
- Removed unused NonTracedHelper class from DepthAccumulationBugTest.kt
- Removed debug println statements from test assertions

# Why
The duplicate test was covering the same depth accumulation bug as the main TDD test. Keeping only the focused regression test reduces maintenance burden and code duplication.