### PR TITLE
Fix context enter event duplication bug

### DIFF
--- a/code-path-tracer/src/main/kotlin/io/github/takahirom/codepathtracer/MethodTraceAdvice.kt
+++ b/code-path-tracer/src/main/kotlin/io/github/takahirom/codepathtracer/MethodTraceAdvice.kt
@@ -3,6 +3,9 @@ package io.github.takahirom.codepathtracer
 /**
  * Data class to represent a method call in the call stack
  */
+/**
+ * Data class to represent a method call context (for backward compatibility)
+ */
 data class CallContext(
     val className: String,
     val methodName: String,
@@ -97,7 +100,7 @@ data class ContextExitTracker(
      * Returns list of context methods that should actually be shown (excluding duplicates).
      * These should be added in reverse order (deepest first) so they can be popped correctly
      */
-    fun queueContextExits(contextMethods: List<CallContext>, startingDepth: Int): List<CallContext> {
+    fun queueContextExits(contextMethods: List<TraceEvent.Enter>, startingDepth: Int): List<TraceEvent.Enter> {
         return contextMethods.mapIndexedNotNull { i, method ->
             val methodKey = ContextMethodKey(method.className, method.methodName, method.depth)
             if (shownContextEnters.add(methodKey)) {
@@ -131,11 +134,14 @@ class MethodTraceAdvice {
         private val actualDepthCounter = ThreadLocal.withInitial { 0 }
         private val depthManager = ThreadLocal<DepthManager>()
         private val isTracing = ThreadLocal.withInitial { false }
-        private val callStack = ThreadLocal<MutableList<CallContext>>()
+        private val callStack = ThreadLocal<MutableList<TraceEvent.Enter>>()
         private val contextExitTracker = ThreadLocal<ContextExitTracker>()
         
         private fun getCallPath(config: CodePathTracer.Config): List<CallContext> {
-            return if (config.beforeContextSize > 0) callStack.get() ?: emptyList() else emptyList()
+            return if (config.beforeContextSize > 0) {
+                // Convert TraceEvent.Enter to CallContext for backward compatibility
+                callStack.get()?.map { CallContext(it.className, it.methodName, it.depth) } ?: emptyList()
+            } else emptyList()
         }
         
         @JvmStatic
@@ -182,9 +188,9 @@ class MethodTraceAdvice {
             try {
                 isTracing.set(true)
                 
-                // Add to call stack if enabled
+                // Add to call stack if enabled - store the complete TraceEvent.Enter
                 if (config.beforeContextSize > 0) {
-                    callStack.get()?.add(CallContext(traceEvent.className, traceEvent.methodName, depth))
+                    callStack.get()?.add(traceEvent as TraceEvent.Enter)
                 }
                 
                 // Apply filter
@@ -232,8 +238,17 @@ class MethodTraceAdvice {
                 if (config.beforeContextSize > 0) {
                     val stack = callStack.get()
                     if (stack != null && stack.size > 1) {
-                        val contextMethods = stack.takeLast(minOf(config.beforeContextSize + 1, stack.size))
+                        val allContextMethods = stack.takeLast(minOf(config.beforeContextSize + 1, stack.size))
                             .dropLast(1) // Remove current method
+                        
+                        // Filter out context methods that would match the current filter
+                        // to prevent duplication (same method appearing as both context and filtered method)
+                        // Now we use the actual TraceEvent.Enter with complete information (args, depth, etc.)
+                        val contextMethods = allContextMethods.filter { contextEvent ->
+                            val wouldPassFilter = config.filter(contextEvent)
+                            // Only include context methods that would NOT pass the filter
+                            !wouldPassFilter
+                        }
                         
                         // Initialize depth manager and context exit tracker if needed
                         val depthMgr = depthManager.get() ?: DepthManager().also { depthManager.set(it) }
@@ -245,10 +260,8 @@ class MethodTraceAdvice {
                         
                         // Generate Enter events only for methods that should be shown
                         methodsToShow.forEachIndexed { i, contextMethod ->
-                            val contextEnterEvent = TraceEvent.Enter(
-                                className = contextMethod.className,
-                                methodName = contextMethod.methodName,
-                                args = arrayOf(),
+                            // Use the original context method but with adjusted depth
+                            val contextEnterEvent = contextMethod.copy(
                                 depth = baseDepth + i,
                                 callPath = currentCallPath
                             )
@@ -256,9 +269,9 @@ class MethodTraceAdvice {
                         }
 
                         // Record the depth information in the depth manager
-                        // Note: We need to account for ALL context methods, not just the ones shown
-                        val allContextMethodsCount = contextMethods.size
-                        val actualMethodDepth = depthMgr.onMethodEnter(allContextMethodsCount)
+                        // Note: We need to account for SHOWN context methods, not all context methods
+                        val shownContextMethodsCount = contextMethods.size
+                        val actualMethodDepth = depthMgr.onMethodEnter(shownContextMethodsCount)
                         
                         
                         // Update the display depth for the actual method entry

--- a/sample-jvm/src/test/kotlin/io/github/takahirom/codepathtracersample/ContextDuplicationBugTest.kt
+++ b/sample-jvm/src/test/kotlin/io/github/takahirom/codepathtracersample/ContextDuplicationBugTest.kt
@@ -1,0 +1,127 @@
+package io.github.takahirom.codepathtracersample
+
+import io.github.takahirom.codepathtracer.CodePathTracer
+import org.junit.Rule
+import org.junit.Test
+import org.junit.Assert.*
+import io.github.takahirom.codepathtracersample.TestUtils.captureOutput
+
+/**
+ * Test to reproduce the context duplication bug where the same method appears twice:
+ * once as a normal filter match and once as a context method.
+ * 
+ * Scenario: A(B(C())) with beforeContextSize=1 and filter=method.contains("B|C")
+ * Expected bug: B appears twice - once as filter match, once as context for C
+ */
+class ContextDuplicationBugTest {
+    
+    @get:Rule
+    val contextDuplicationRule = CodePathTracer.Builder()
+        .filter { event ->
+            // Filter matches both B and C methods
+            event.className.contains("DuplicationBugHierarchy") && 
+            (event.methodName.contains("B") || event.methodName.contains("C"))
+        }
+        .beforeContextSize(1)  // Show 1 level of context
+        .asJUnitRule()
+    
+    @Test
+    fun testContextDuplicationBug() {
+        val output = captureOutput {
+            val test = DuplicationBugHierarchy()
+            test.methodA()  // A -> B -> C, filter matches B and C
+        }
+        
+        val traceLines = output.lines()
+            .filter { it.contains("→") || it.contains("←") }
+        
+        println("=== Trace output ===")
+        traceLines.forEach { println(it) }
+        
+        // Current bug: B appears twice
+        // 1. As context for C (because beforeContextSize=1)
+        // 2. As a filtered method itself (because it matches the filter)
+        
+        // Count occurrences of methodB in enter events
+        val methodBEnterCount = traceLines.count { 
+            it.contains("→") && it.contains("methodB") 
+        }
+        
+        // Count occurrences of methodB in exit events  
+        val methodBExitCount = traceLines.count { 
+            it.contains("←") && it.contains("methodB") 
+        }
+        
+        // This test should FAIL initially to demonstrate the bug
+        // B should appear only once, not twice
+        assertEquals("methodB should appear exactly once in enter events (currently fails due to duplication bug)", 1, methodBEnterCount)
+        assertEquals("methodB should appear exactly once in exit events (currently fails due to duplication bug)", 1, methodBExitCount)
+        
+        // Expected correct output should be:
+        // → DuplicationBugHierarchy.methodB()  (context for C)
+        //  → DuplicationBugHierarchy.methodC()  (filtered method)
+        //  ← DuplicationBugHierarchy.methodC
+        // ← DuplicationBugHierarchy.methodB
+        //
+        // NOT:
+        // → DuplicationBugHierarchy.methodB()  (context for C)  
+        //  → DuplicationBugHierarchy.methodB()  (filtered method) - DUPLICATE!
+        //   → DuplicationBugHierarchy.methodC()  (filtered method)
+        //   ← DuplicationBugHierarchy.methodC
+        //  ← DuplicationBugHierarchy.methodB
+        // ← DuplicationBugHierarchy.methodB
+    }
+    
+    @Test
+    fun testExpectedCorrectOutput() {
+        val output = captureOutput {
+            val test = DuplicationBugHierarchy()
+            test.methodA()
+        }
+        
+        val traceLines = output.lines()
+            .filter { it.contains("→") || it.contains("←") }
+        
+        // After fix, expected output should be exactly 6 lines:
+        // - methodA as context for methodB (methodA doesn't match filter)
+        // - methodB as filtered method (methodB matches filter)  
+        // - methodC as filtered method (methodC matches filter)
+        // - corresponding exits
+        assertEquals("Should have exactly 6 trace lines after fix", 6, traceLines.size)
+        
+        // Verify the exact sequence (corrected expectation)
+        assertEquals("Should show context enter for methodA", "→ DuplicationBugHierarchy.methodA()", traceLines[0])
+        assertEquals("Should show method enter for methodB", " → DuplicationBugHierarchy.methodB()", traceLines[1])
+        assertEquals("Should show method enter for methodC", "  → DuplicationBugHierarchy.methodC()", traceLines[2])
+        assertEquals("Should show method exit for methodC", "  ← DuplicationBugHierarchy.methodC", traceLines[3])
+        assertEquals("Should show method exit for methodB", " ← DuplicationBugHierarchy.methodB", traceLines[4])
+        assertEquals("Should show context exit for methodA", "← DuplicationBugHierarchy.methodA", traceLines[5])
+        
+        // Critical: Verify NO duplication of methodB
+        val methodBEnterCount = traceLines.count { 
+            it.contains("→") && it.contains("methodB") 
+        }
+        assertEquals("methodB should appear exactly once in enter events (no duplication)", 1, methodBEnterCount)
+        
+        // Verify indentation levels are correct 
+        assertTrue("methodA context should have no indentation", traceLines[0].startsWith("→"))
+        assertTrue("methodB should be indented 1 level", traceLines[1].startsWith(" →"))
+        assertTrue("methodC should be indented 2 levels", traceLines[2].startsWith("  →"))
+    }
+}
+
+class DuplicationBugHierarchy {
+    fun methodA() {
+        println("Executing methodA")
+        methodB()
+    }
+    
+    fun methodB() {
+        println("Executing methodB")
+        methodC()
+    }
+    
+    fun methodC() {
+        println("Executing methodC")
+    }
+}


### PR DESCRIPTION
# What
Fixed context enter event duplication where methods appeared twice - once as context and once as filtered method when using beforeContextSize with filters that match context methods.

# Why  
When a method in the context chain matched the filter (e.g., method.contains("B|C")), it was incorrectly displayed both as context for deeper methods and as a filtered method itself, causing confusing duplicate output. The fix ensures accurate filter evaluation using complete TraceEvent information and proper depth calculation.