### PR TITLE
Fix README trace output format example

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,8 +44,10 @@ val traceRule = CodePathTracer.Builder()
 **Output reveals the touch event flow:**
 ```
 → PhoneWindow.superDispatchTouchEvent(MotionEvent)
-  → ViewGroup.onInterceptTouchEvent() = false
-  → TextView.onTouchEvent(MotionEvent) = true ✅
+  → ViewGroup.onInterceptTouchEvent(MotionEvent)
+  ← ViewGroup.onInterceptTouchEvent = false
+  → TextView.onTouchEvent(MotionEvent)
+  ← TextView.onTouchEvent = true ✅
 ← PhoneWindow.superDispatchTouchEvent = true
 ```
 


### PR DESCRIPTION
# What
Fixed the touch event flow example in README to properly show Enter/Exit events with correct format.

# Why
The previous format showed confusing duplicate arrows and mixed Enter/Exit event formatting. Now properly separates method entry and exit events to match the actual TraceEvent implementation output.