### PR TITLE
Update CodePathTracerRule docs to match new API

### DIFF
--- a/code-path-tracer/src/main/kotlin/io/github/takahirom/codepathtracer/CodePathTracerRule.kt
+++ b/code-path-tracer/src/main/kotlin/io/github/takahirom/codepathtracer/CodePathTracerRule.kt
@@ -14,13 +14,13 @@ object DefaultFilter {
  * Usage:
  * ```
  * @get:Rule
- * val codePathTracerRule = CodePathTracerRule.builder()
- *     .packageIncludes("io.github.takahirom.codepathtracer")
- *     .methodExcludes("toString", "hashCode", "equals")
- *     .build()
+ * val codePathTracerRule = CodePathTracer.Builder()
+ *     .filter { event -> event.className.contains("MyClass") }
+ *     .formatter { event -> "Custom: ${event.methodName}" }
+ *     .asJUnitRule()
  *
  * // Or with custom filter/formatter
- * val customRule = CodePathTracerRule.builder()
+ * val customRule = CodePathTracer.Builder()
  *     .filter { event ->
  *         event.className.startsWith("com.example") &&
  *         event.depth < 5
@@ -28,7 +28,7 @@ object DefaultFilter {
  *     .formatter { event ->
  *         "${" ".repeat(event.depth)}${event.fullMethodName}(${event.args.size})"
  *     }
- *     .build()
+ *     .asJUnitRule()
  * ```
  */
 class CodePathTracerRule internal constructor(


### PR DESCRIPTION
# What
Update documentation comments in CodePathTracerRule.kt to reflect the current API pattern

# Why
The documentation was outdated - it showed the old builder pattern (CodePathTracerRule.builder()) instead of the new unified API (CodePathTracer.Builder().asJUnitRule())